### PR TITLE
Various minor performance and readability improvements: Signaling: changed to reference instead of multiple copies. JuiceManager / SNETADDR: Created constructor for gamepacket so we can use .emplace() instead of .push()

### DIFF
--- a/SNP/JuiceManager.cpp
+++ b/SNP/JuiceManager.cpp
@@ -93,15 +93,8 @@ void JuiceWrapper::on_gathering_done(juice_agent_t* agent, void* user_ptr)
 }
 void JuiceWrapper::on_recv(juice_agent_t* agent, const char* data, size_t size, void* user_ptr)
 {
-
 	JuiceWrapper* parent = (JuiceWrapper*)user_ptr;
-
-	GamePacket gamePacket;
-	memcpy(gamePacket.data, data, size);
-	gamePacket.packetSize = size;
-	gamePacket.sender = parent->m_ID;
-	gamePacket.timeStamp = GetTickCount();
-	receive_queue.push(GamePacket(gamePacket));
+	receive_queue.emplace(GamePacket{ parent->m_ID,data,size });
 	SetEvent(receiveEvent);
 }
 

--- a/SNP/JuiceP2P.cpp
+++ b/SNP/JuiceP2P.cpp
@@ -22,7 +22,7 @@ namespace JP2P
     struct AdFile
     {
         game gameInfo;
-        char extraBytes[32];
+        char extraBytes[32] = "";
     };
 
     SNP::NetworkInfo networkInfo = { nName, 'JP2P', nDesc,
@@ -46,6 +46,7 @@ namespace JP2P
     }
     void JuiceP2P::destroy()
     {
+        //TODO cleanup properly so we don't get an error on close
     }
     void JuiceP2P::requestAds()
     {
@@ -61,15 +62,8 @@ namespace JP2P
     void JuiceP2P::receive() {};//unused
     void JuiceP2P::sendAsyn(const SNETADDR& peer_ID, Util::MemoryFrame packet)
     {
-        // create header
-        char sendBufferBytes[600];
-        Util::MemoryFrame sendBuffer(sendBufferBytes, 600);
-        Util::MemoryFrame spacket = sendBuffer;
-        spacket.write(packet);
-
-        // send packet
-        std::string peer_str((char*)peer_ID.address, sizeof(SNETADDR));
-        juice_manager.send_p2p(peer_str, packet);
+        juice_manager.send_p2p(
+            std::string((char*)peer_ID.address,sizeof(SNETADDR)), packet);
     }
 
     void JuiceP2P::receive_signaling()
@@ -82,9 +76,8 @@ namespace JP2P
         AdFile ad;
         std::string decoded_data;
 
-        // should block here now
         while (true) {
-            incoming_packets = signaling_socket.receive_packets();
+            signaling_socket.receive_packets(incoming_packets);
             log_trace.debug("received incoming signaling");
             for (auto packet : incoming_packets)
             {

--- a/SNP/SNETADDR.h
+++ b/SNP/SNETADDR.h
@@ -5,9 +5,7 @@
 #include <string>
 
 struct SNETADDR {
-    SNETADDR() {
-        memset(&address, 0, sizeof(SNETADDR));
-    };
+    SNETADDR() = default;
     SNETADDR(BYTE* addr)
     {
         memcpy(&address, addr, sizeof(SNETADDR));
@@ -26,6 +24,13 @@ struct SNETADDR {
 
 struct GamePacket
 {
+    GamePacket() = default;
+    GamePacket(SNETADDR& sender_ID, const char* recv_data, const size_t size) {
+        sender = SNETADDR(sender_ID);
+        timeStamp = GetTickCount();
+        packetSize = size;
+        memcpy(data, recv_data, size);
+    };
     SNETADDR sender;
     int packetSize;
     DWORD timeStamp;

--- a/SNP/Storm/storm.h
+++ b/SNP/Storm/storm.h
@@ -1314,7 +1314,7 @@ namespace Storm
       , valid( SFileOpenFileEx(hMpq, sFileName.c_str(), flags, &hFile) != FALSE )
     { }
 
-    CFile(CFile &&other)
+    CFile(CFile &&other) noexcept
       : hFile( other.hFile )
       , valid( other.valid ) 
     {

--- a/SNP/signaling.h
+++ b/SNP/signaling.h
@@ -63,7 +63,7 @@ namespace signaling
 		void release() noexcept;
 		void send_packet(SNETADDR dest, const Signal_message_type msg_type, std::string msg = "");
 		void send_packet(const Signal_packet);
-		std::vector<Signal_packet> receive_packets();
+		void receive_packets(std::vector<Signal_packet>& incoming_packets);
 		void set_blocking_mode(bool block);
 		void start_advertising();
 		void stop_advertising();
@@ -71,7 +71,7 @@ namespace signaling
 		SNETADDR server;
 
 	private:
-		std::vector<Signal_packet> split_into_packets(const std::string& s);
+		void split_into_packets(const std::string& s, std::vector<Signal_packet>& incoming_packets);
 		SOCKET m_sockfd;
 		int m_state;
 		const std::string m_delimiter;


### PR DESCRIPTION
Signaling: changed to reference instead of multiple copies.
JuiceManager / SNETADDR: Created constructor for gamepacket so we can use .emplace() instead of .push()