### PR TITLE
Client reconnect with same ID now possible

### DIFF
--- a/SNP/CrownLink.cpp
+++ b/SNP/CrownLink.cpp
@@ -37,18 +37,22 @@ void CrownLink::receive_signaling(){
 	std::vector<SignalPacket> incoming_packets;
 	while (m_is_running) {
 		g_signaling_socket.receive_packets(incoming_packets);
-		// m_logger.trace("received incoming signaling");
 		for (const auto& packet : incoming_packets) {
 			switch (packet.message_type) {
+				case SignalMessageType::ServerSetID:
+				{
+					if (m_client_id_set) {
+						g_signaling_socket.set_client_id(m_client_id.b64());
+					} else {
+						m_client_id = base64::from_base64(packet.data);
+						m_client_id_set = true;
+					}
+				} break;
 				case SignalMessageType::StartAdvertising: {
-					m_logger.debug("server confirmed lobby open");
 				} break;
 				case SignalMessageType::StopAdvertising: {
-					m_logger.debug("server confirmed lobby closed");
 				} break;
 				case SignalMessageType::RequestAdvertisers: {
-					// list of advertisers returned
-					// split into individual addresses & create juice peers
 					update_known_advertisers(packet.data);
 				} break;
 				case SignalMessageType::SolicitAds: {

--- a/SNP/CrownLink.cpp
+++ b/SNP/CrownLink.cpp
@@ -33,76 +33,102 @@ void CrownLink::sendAsyn(const SNetAddr& peer_ID, Util::MemoryFrame packet){
 	g_juice_manager.send_p2p(std::string((char*)peer_ID.address, sizeof(SNetAddr)), packet.begin(), packet.size());
 }
 
-void CrownLink::receive_signaling(){
+void CrownLink::receive_signaling() {
 	std::vector<SignalPacket> incoming_packets;
+	auto n_bytes = 0;
+	auto ws_error = 0;
 	while (m_is_running) {
-		g_signaling_socket.receive_packets(incoming_packets);
-		for (const auto& packet : incoming_packets) {
-			switch (packet.message_type) {
-				case SignalMessageType::ServerSetID:
-				{
-					if (m_client_id_set) {
-						g_signaling_socket.set_client_id(m_client_id.b64());
-					} else {
-						m_client_id = base64::from_base64(packet.data);
-						m_client_id_set = true;
-					}
-				} break;
-				case SignalMessageType::StartAdvertising: {
-				} break;
-				case SignalMessageType::StopAdvertising: {
-				} break;
-				case SignalMessageType::RequestAdvertisers: {
-					update_known_advertisers(packet.data);
-				} break;
-				case SignalMessageType::SolicitAds: {
-					if (m_is_advertising) {
-						m_logger.debug("received solicitation from {}, replying with our lobby info", packet.peer_id.b64());
-						std::string send_buffer;
-						send_buffer.append((char*)m_ad_data.begin(), m_ad_data.size());
-						g_signaling_socket.send_packet(packet.peer_id, SignalMessageType::GameAd,
-							base64::to_base64(send_buffer));
-					}
-				} break;
-				case SignalMessageType::GameAd: {
-					// -------------- PACKET: GAME STATS -------------------------------
-					// Give the ad to storm
-					m_logger.debug("received lobby info from {}", packet.peer_id.b64());
-					auto decoded_data = base64::from_base64(packet.data);
-					AdFile ad{};
-					memcpy_s(&ad, sizeof(ad), decoded_data.c_str(), decoded_data.size());
-					snp::passAdvertisement(packet.peer_id, Util::MemoryFrame::from(ad));
-
-					m_logger.debug("Game Info Received:\n"
-						"  dwIndex: {}\n"
-						"  dwGameState: {}\n"
-						"  saHost: {}\n"
-						"  dwTimer: {}\n"
-						"  szGameName[128]: {}\n"
-						"  szGameStatString[128]: {}\n"
-						"  dwExtraBytes: {}\n"
-						"  dwProduct: {}\n"
-						"  dwVersion: {}\n",
-						ad.game_info.dwIndex,
-						ad.game_info.dwGameState,
-						ad.game_info.saHost.b64(),
-						ad.game_info.dwTimer,
-						ad.game_info.szGameName,
-						ad.game_info.szGameStatString,
-						ad.game_info.dwExtraBytes,
-						ad.game_info.dwProduct,
-						ad.game_info.dwVersion
-					);
-				} break;
-				case SignalMessageType::JuiceLocalDescription:
-				case SignalMessageType::JuciceCandidate:
-				case SignalMessageType::JuiceDone: {
-					g_juice_manager.handle_signal_packet(packet);
-				} break;
-			}
+		g_signaling_socket.receive_packets(incoming_packets, n_bytes, ws_error);
+		if (!m_is_running) return;
+		if (n_bytes > 0) {
+			signal_handler(incoming_packets);
+		} else {
+			error_handler(n_bytes,ws_error);
 		}
 	}
 }
+
+void CrownLink::signal_handler(std::vector<SignalPacket>& incoming_packets) {
+	for (const auto& packet : incoming_packets) {
+		switch (packet.message_type) {
+			case SignalMessageType::ServerSetID:
+			{
+				if (m_client_id_set) {
+					g_signaling_socket.set_client_id(m_client_id.b64());
+				} else {
+					m_client_id = base64::from_base64(packet.data);
+					m_logger.info("received client ID from server: {}", m_client_id.b64());
+					m_client_id_set = true;
+				}
+			} break;
+			case SignalMessageType::StartAdvertising: {
+			} break;
+			case SignalMessageType::StopAdvertising: {
+			} break;
+			case SignalMessageType::RequestAdvertisers: {
+				update_known_advertisers(packet.data);
+			} break;
+			case SignalMessageType::SolicitAds: {
+				if (m_is_advertising) {
+					m_logger.debug("received solicitation from {}, replying with our lobby info", packet.peer_id.b64());
+					std::string send_buffer;
+					send_buffer.append((char*)m_ad_data.begin(), m_ad_data.size());
+					g_signaling_socket.send_packet(packet.peer_id, SignalMessageType::GameAd,
+						base64::to_base64(send_buffer));
+				}
+			} break;
+			case SignalMessageType::GameAd: {
+				// -------------- PACKET: GAME STATS -------------------------------
+				// Give the ad to storm
+				m_logger.debug("received lobby info from {}", packet.peer_id.b64());
+				auto decoded_data = base64::from_base64(packet.data);
+				AdFile ad{};
+				memcpy_s(&ad, sizeof(ad), decoded_data.c_str(), decoded_data.size());
+				snp::passAdvertisement(packet.peer_id, Util::MemoryFrame::from(ad));
+
+				m_logger.debug("Game Info Received:\n"
+					"  dwIndex: {}\n"
+					"  dwGameState: {}\n"
+					"  saHost: {}\n"
+					"  dwTimer: {}\n"
+					"  szGameName[128]: {}\n"
+					"  szGameStatString[128]: {}\n"
+					"  dwExtraBytes: {}\n"
+					"  dwProduct: {}\n"
+					"  dwVersion: {}\n",
+					ad.game_info.dwIndex,
+					ad.game_info.dwGameState,
+					ad.game_info.saHost.b64(),
+					ad.game_info.dwTimer,
+					ad.game_info.szGameName,
+					ad.game_info.szGameStatString,
+					ad.game_info.dwExtraBytes,
+					ad.game_info.dwProduct,
+					ad.game_info.dwVersion
+				);
+			} break;
+			case SignalMessageType::JuiceLocalDescription:
+			case SignalMessageType::JuciceCandidate:
+			case SignalMessageType::JuiceDone: {
+				g_juice_manager.handle_signal_packet(packet);
+			} break;
+		}
+	}
+}
+void CrownLink::error_handler(int n_bytes, int ws_error) {
+	// winsock error codes: https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2
+
+	if (n_bytes == 0) {
+		m_logger.error("connection to server closed, attempting reconnect");
+	} else {
+		m_logger.error("winsock error {} received, attempting reconnect", ws_error);
+	}
+	g_signaling_socket.deinitialize();
+	std::this_thread::sleep_for(std::chrono::seconds(1));
+	g_signaling_socket.initialize();
+}
+
+
 
 void CrownLink::update_known_advertisers(const std::string& data) {
 	m_known_advertisers.clear();

--- a/SNP/CrownLink.h
+++ b/SNP/CrownLink.h
@@ -35,8 +35,10 @@ public:
 	void sendAsyn(const SNetAddr& to, Util::MemoryFrame packet) override;
 	void startAdvertising(Util::MemoryFrame ad) override;
 	void stopAdvertising() override;
-
+private:
 	void receive_signaling();
+	void signal_handler(std::vector<SignalPacket>& incoming_packets);
+	void error_handler(int n_bytes, int ws_error);
 	void update_known_advertisers(const std::string& message);
 
 private:

--- a/SNP/CrownLink.h
+++ b/SNP/CrownLink.h
@@ -47,6 +47,8 @@ private:
 	bool m_is_running = true;
     std::stop_source m_stop_source;
 	Logger m_logger{g_root_logger, "Juice"};
+	SNetAddr m_client_id;
+	bool m_client_id_set = false;
 };
 
 };

--- a/SNP/signaling.cpp
+++ b/SNP/signaling.cpp
@@ -116,48 +116,16 @@ void SignalingSocket::split_into_packets(const std::string& s,std::vector<Signal
 	}
 }
 
-void SignalingSocket::receive_packets(std::vector<SignalPacket>& incoming_packets){
+void SignalingSocket::receive_packets(std::vector<SignalPacket>& incoming_packets, int& n_bytes, int& ws_error) {
 	constexpr unsigned int MAX_BUF_LENGTH = 4096;
 	std::vector<char> buffer(MAX_BUF_LENGTH);
 	std::string receive_buffer;
-	auto n_bytes = recv(m_socket, &buffer[0], buffer.size(), 0);
-	if (n_bytes == SOCKET_ERROR) {
-		m_last_error = WSAGetLastError();
-		m_logger.debug("receive error: {}", m_last_error);
-		//if (m_last_error == WSAEWOULDBLOCK) {
-		//	// We're waiting for data or connection is reset
-		//	// this is legacy of the old non-blocking code
-		//	// we now block in a thread instead
-		//	return;
-		//}
-		if (m_last_error == WSAECONNRESET) {
-			// Connection reset by server
-			// not sure if this should be a fatal or something
-			m_logger.error("signaling socket receive error: connection reset by server, attempting reconnect");
-			deinitialize();
-			std::this_thread::sleep_for(std::chrono::seconds(1));
-			initialize();
-
-		}
-		if (m_last_error == WSAECONNABORTED) {
-			m_logger.error("connection aborted");
-		}
-		// else throw GeneralException("::recv failed");
-	}
-	if (n_bytes <1) {
-		// 0 = connection closed by remote end
-		// -1 = winsock error
-		// anything more = we actually got data
-		m_logger.error("server connection closed, attempting reconnect");
-		deinitialize();
-		std::this_thread::sleep_for(std::chrono::seconds(1));
-		initialize();
-	} else {
+	n_bytes = recv(m_socket, &buffer[0], buffer.size(), 0);
+	if(n_bytes) {
 		buffer.resize(n_bytes);
 		receive_buffer.append(buffer.begin(), buffer.end());
 		split_into_packets(receive_buffer, incoming_packets);
 		m_logger.trace("received {}", n_bytes);
-		return;
 	}
 }
 

--- a/SNP/signaling.cpp
+++ b/SNP/signaling.cpp
@@ -183,3 +183,7 @@ void SignalingSocket::request_advertisers(){
 void SignalingSocket::echo(std::string data) {
 	send_packet(m_server, SignalMessageType::ServerEcho, data);
 }
+
+void SignalingSocket::set_client_id(std::string id) {
+	send_packet(m_server, SignalMessageType::ServerSetID, id);
+}

--- a/SNP/signaling.h
+++ b/SNP/signaling.h
@@ -92,6 +92,7 @@ public:
 	void stop_advertising();
 	void request_advertisers();
 	void echo(std::string data);
+	void set_client_id(std::string id);
 	
 private:
 	void split_into_packets(const std::string& s, std::vector<SignalPacket>& incoming_packets);

--- a/SNP/signaling.h
+++ b/SNP/signaling.h
@@ -86,7 +86,7 @@ public:
 	void deinitialize();
 	void send_packet(SNetAddr dest, SignalMessageType msg_type, const std::string& msg = "");
 	void send_packet(const SignalPacket& packet);
-	void receive_packets(std::vector<SignalPacket>& incoming_packets);
+	void receive_packets(std::vector<SignalPacket>& incoming_packets, int& n_bytes, int& ws_error);
 	void set_blocking_mode(bool block);
 	void start_advertising();
 	void stop_advertising();

--- a/signaling/server.py
+++ b/signaling/server.py
@@ -187,7 +187,9 @@ class ServerProtocol(asyncio.Protocol):
                     self.send_advertisers()
                 
                 case Signal_message_type.SERVER_SET_ID:
-                    self.peer_ID_base64 = packet.data;
+                    original_peer_id = self.peer_ID
+                    self.peer_ID_base64 = packet.data
+                    CONNECTIONS[self.peer_ID] = CONNECTIONS.pop(original_peer_id)
                 
                 case Signal_message_type.SERVER_ECHO:
                     self.send_packet(packet);


### PR DESCRIPTION
- SignalingSocket::receive_packets() now passes bytes received and error code as well as packets
- Crownlink::receive_signaling() now detects winsock disconnect or errors and runs error_handler if needed
- error_handler deinitializes signaling socket, waits 2s, then attempts initialization
- server sends assigned client ID to the client upon connect
- if this is a fresh connection client will save the client ID
- if this is a reconnect then client will request the server switch back to original client ID